### PR TITLE
Fix: Slider img load, header font and spacings

### DIFF
--- a/styles/header.scss
+++ b/styles/header.scss
@@ -38,7 +38,7 @@ header {
         margin-left: 6%;
         margin-left: 2vw;
 
-        font-size: 22px;
+        font-size: 1.375rem;
         font-weight: 500;
         letter-spacing: 0.05em;
         color: $link-color;
@@ -113,8 +113,8 @@ header {
       display: flex;
       flex-flow: row nowrap;
       height: auto;
-      width: 30%;
-      width: 30vw;
+      width: 32%;
+      width: 32vw;
 
       margin-right: 7%;
       margin-right: 7vw;

--- a/styles/mainSlider.scss
+++ b/styles/mainSlider.scss
@@ -39,6 +39,7 @@
   }
 
   .main-slider-item {
+    height: 82%;
     width: 100%;
     width: 100vw;
   }


### PR DESCRIPTION
- [x] Define slider container height before image load so that content doesn't collapse
- [x] Replace `px` with `rem` for font size in header