### PR TITLE
Fix: missing click events

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2,8 +2,6 @@ import polyfill from './polyfill'
 import hamburgerMenu from './handlers/hamburgerMenu'
 import cardButton from './handlers/cardButton'
 
-document.addEventListener('DOMContentLoaded', () => {
-  polyfill()
-  hamburgerMenu()
-  cardButton()
-})
+polyfill()
+hamburgerMenu()
+cardButton()


### PR DESCRIPTION
- Script was loaded after the `DOMContentLoaded` event, therefore it was never executed.
- Now, script executes immediately after it's loaded and attaches needed event listeners